### PR TITLE
Feature/#10 develop site infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_store
+public/

--- a/LICENSE.html
+++ b/LICENSE.html
@@ -5,7 +5,7 @@
     <script id="_fed_an_js_tag" type="text/javascript"
             src="https://worldwind.arc.nasa.gov/js/libs/analytics/federatedanalytics.all.min.js?agency=NASA&sub-agency=ARC&vcto=12"></script>
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-    <title>NASA World Wind License</title>
+    <title>NASA WorldWind License</title>
     <style type="text/css">
         <!--
         .style2 {
@@ -55,7 +55,7 @@
 <body>
 <table width="650" border="0" cellspacing="0" cellpadding="0">
     <tr>
-        <td><p class="style14"><span class="style4"> NASA WORLD WIND </span></p>
+        <td><p class="style14"><span class="style4"> NASA WorldWind </span></p>
             <p class="style2">Copyright &copy; 2004-2005 United States Government as represented by the Administrator of
                 the National Aeronautics and Space Administration. All Rights Reserved.<br>
                 Copyright &copy; 2004-2005 Contributors. All Rights Reserved.
@@ -73,7 +73,7 @@
                 CONTAINED IN THIS AGREEMENT. </p>
             <p class="style2">Government Agency: National Aeronautics and Space Administration (NASA)<br>
                 Government Agency Original Software Designation: ARC-15166-1<br>
-                Government Agency Original Software Title: NASA World Wind<br>
+                Government Agency Original Software Title: NASA WorldWind<br>
                 User Registration Requested. Please send email with your contact information to
                 Patrick.Hogan@nasa.gov<br>
                 Government Agency Point of Contact for Original Software: Patrick.Hogan@nasa.gov </p>

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,40 +1,40 @@
 <img src="https://nasaworldwind.github.io/css/images/nasa-logo.svg" height="100"/>
 
-# NASA World Wind Team
+# NASA WorldWind Team
 
-Welcome to the NASA World Wind team! This guide helps you get connected, explore the various resources you'll need as a
-team member, and start developing code for NASA World Wind.
+Welcome to the NASA WorldWind team! This guide helps you get connected, explore the various resources you'll need as a
+team member, and start developing code for NASA WorldWind.
 
-- [worldwind.arc.nasa.gov](https://worldwind.arc.nasa.gov) has all things World Wind in one place
+- [worldwind.arc.nasa.gov](https://worldwind.arc.nasa.gov) has all things WorldWind in one place
 - [GitHub](https://github.com/NASAWorldWind) hosts source code, issues, milestones, and releases
 - [Travis CI](https://travis-ci.org/NASAWorldWind) provides continuous integration and build automation
-- [World Wind Forum](https://forum.worldwindcentral.com) provides help and outreach to the World Wind community
+- [WorldWind Forum](https://forum.worldwindcentral.com) provides help and outreach to the WorldWind community
 
 ## Get Connected
 
 - [GitHub](https://github.com) account with two-factor authentication enabled
 - [Skype](https://login.skype.com/account/signup-form) account
 - [JetBrains](https://account.jetbrains.com/login) account
-- [World Wind Forum](http://forum.worldwindcentral.com/register.php) account (NASA interns skip this step)
+- [WorldWind Forum](http://forum.worldwindcentral.com/register.php) account (NASA interns skip this step)
 ... Set Avatar to NASA logo
 ... Set User Title to 'WW Team Member'
 ... Set Biography to 'NASA WorldWind Team Member'
 
-[Send a request](mailto:worldwind@googlegroups.com) to get connected with the World Wind team. Include your GitHub account, Skype account, JetBrains account, and Forum account.
+[Send a request](mailto:worldwind@googlegroups.com) to get connected with the WorldWind team. Include your GitHub account, Skype account, JetBrains account, and Forum account.
 
 ## Accept Invitations To
 
-- World Wind [GitHub organization](https://github.com/orgs/NASAWorldWind/people)
-- World Wind [GitHub team](https://github.com/orgs/NASAWorldWind/teams/nasa-developers)
+- WorldWind [GitHub organization](https://github.com/orgs/NASAWorldWind/people)
+- WorldWind [GitHub team](https://github.com/orgs/NASAWorldWind/teams/nasa-developers)
 
 ## Joining Team Meetings
 
-- World Wind internal meeting, Tuesdays at 1300 Pacific Time
-- World Wind developers meeting, Tuesdays and Thursdays at 1100 Pacific Time
+- WorldWind internal meeting, Tuesdays at 1300 Pacific Time
+- WorldWind developers meeting, Tuesdays and Thursdays at 1100 Pacific Time
 - ESA meeting, Tuesdays at 1800 Central European Time
 
 ## Start Developing
 
-- [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) for World Wind Java
-- [WebStorm](https://www.jetbrains.com/webstorm/download/) for Web World Wind
-- [Android Studio](https://developer.android.com/studio/) for World Wind Android
+- [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) for WorldWind Java
+- [WebStorm](https://www.jetbrains.com/webstorm/download/) for Web WorldWind
+- [Android Studio](https://developer.android.com/studio/) for WorldWind Android

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NASAWorldWind.github.io
 
-This repository is home to the NASA World Wind website which is hosted on GitHub Pages [https://nasaworldwind.github.io/](https://nasaworldwind.github.io/) and at [https://worldwind.arc.nasa.gov/](https://worldwind.arc.nasa.gov). The site should provide helpful information for users interested in World Wind's different projects.
+This repository is home to the NASA WorldWind website which is hosted on GitHub Pages [https://nasaworldwind.github.io/](https://nasaworldwind.github.io/) and at [https://worldwind.arc.nasa.gov/](https://worldwind.arc.nasa.gov). The site should provide helpful information for users interested in WorldWind's different projects.
 
 The site itself is generated with [Hugo](https://gohugo.io/) from the markdown and html templates found within the repository. Hugo transforms the markdown formatting to plain html and injects the content into the templates to form the final html files. Producing content in markdown provides a similar experience to creating and commenting on issues in GitHub while still providing enough formatting to facilitate communication of a topic.
 
@@ -24,7 +24,7 @@ To generate the site, simply execute `$ hugo` from the root project directory. H
 
 ## Site Structure
 
-The primary goal of the website is to communicate how to use each of the World Wind projects. The projects share a common structure detailed below:
+The primary goal of the website is to communicate how to use each of the WorldWind projects. The projects share a common structure detailed below:
 ```
 / (main page)
 |---about
@@ -94,7 +94,7 @@ layout = "project" // Overrides the "single.html" default template to include th
 
 ## Adding Content
 
-Too add content, place a markdown file in the `content` directory. Markdown files require [front matter](http://gohugo.io/content/front-matter/) and as detailed in the *Site Structure* section, specific keys are required for the World Wind website to generate properly.
+Too add content, place a markdown file in the `content` directory. Markdown files require [front matter](http://gohugo.io/content/front-matter/) and as detailed in the *Site Structure* section, specific keys are required for the WorldWind website to generate properly.
 
 Hugo uses [archetypes](http://gohugo.io/content/archetypes/) to facilitate the orderly creation of content. Archetypes are optional, there is no restriction on manually generating a markdown file in the directory structure; however, by using archetypes, the front matter, including additional key and values, will be automatically generated.
 
@@ -102,7 +102,7 @@ To use an archetype to create content, simply execute the following:
 ```
 hugo new <path to location of new content>/<markdown file name>.md
 ```
-To generate the "get-started.md" file/page in the World Wind Android project using the project structure detailed in the *Site Structure* section would look like this:
+To generate the "get-started.md" file/page in the WorldWind Android project using the project structure detailed in the *Site Structure* section would look like this:
 ```
 hugo new android/get-started.md
 ```
@@ -110,7 +110,7 @@ Notice the `content` directory is implied and not required for the `hugo new` co
 
 ## License
 
-    NASA WORLD WIND
+    NASA WorldWind
 
     Copyright (C) 2001 United States Government
     as represented by the Administrator of the
@@ -131,7 +131,7 @@ Notice the `content` directory is implied and not required for the `hugo new` co
 
     Government Agency: National Aeronautics and Space Administration (NASA)
     Government Agency Original Software Designation: ARC-15166-1
-    Government Agency Original Software Title: NASA World Wind
+    Government Agency Original Software Title: NASA WorldWind
     User Registration Requested. Please send email with your contact information to Patrick.Hogan@nasa.gov
     Government Agency Point of Contact for Original Software: Patrick.Hogan@nasa.gov
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,44 @@ Key Value | List Template Style
 --- | --- 
 `mainpage = true` | _index.md content in the main body
 `projectpage = true` | _index.md content in the main body and project header
-*neither* | _index.md content above an enumeration of child content
+*neither* | _index.md content above with an enumeration of child content
 
 Incorporating the content conditionals into the `_default/list.html` template allows the utilization of a single template. The flexibility in the templating language allows the multiple content types to be appropriately handled. Custom formating of the content is still provided by the flexibility of markdown.
+
+The key/values described above are only part of the NASA site required front matter. The additional key/value front matter pairs are described below:
+
+Key | Required? | Purpose | Example Value
+--- | --- | --- | ---
+`projectslug` | if the content is part of a project | provides the project slug when generating urls | `android`
+`projectname` | if the content is part of a project | provides nicely formatted project name for content | `WorldWind Android`
+`listdescription` | if the file will be part of a list | provides a short description in the indexed or list view | `Details how to...`
+
+To provide an example of how to use front matter when authoring content, see the example front matter portions of select markdown files in the Android project:
+
+Android Get Started page:
+```yaml
+---
+title = "Get Started"
+mainpage = false
+projectpage = true
+projectslug = "android"
+projectname = "WorldWind Android"
+listdescription = ""
+---
+```
+
+Android WMS Layer Tutorial Page:
+```yaml
+---
+title = "WMS Layer"
+mainpage = false
+projectpage = false // While this is part of a project, it is not a primary project page
+projectslug = "android"
+projectname = "WorldWind Android"
+listdescription = "Details the steps to add WMS data to the globe."
+layout = "project" // Overrides the "single.html" default template to include the project navbar
+---
+```
 
 ## Adding Content
 

--- a/archetypes/android.md
+++ b/archetypes/android.md
@@ -4,7 +4,7 @@ date: {{ .Date }}
 draft: false
 mainpage: false
 projectpage: false
-projectslug: ""
-projectname: ""
+projectslug: "android"
+projectname: "WorldWind Android"
 listdescription: ""
 ---

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,8 @@
+---
+title: "{{ replace .TranslationBaseName "-" " " | title }}"
+date: {{ .Date }}
+draft: false
+mainpage: false
+projectpage: false
+---
+

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -4,5 +4,5 @@ date: {{ .Date }}
 draft: false
 mainpage: false
 projectpage: false
+projectslug: ""
 ---
-

--- a/archetypes/java.md
+++ b/archetypes/java.md
@@ -4,7 +4,7 @@ date: {{ .Date }}
 draft: false
 mainpage: false
 projectpage: false
-projectslug: ""
-projectname: ""
+projectslug: "java"
+projectname: "WorldWind Java"
 listdescription: ""
 ---

--- a/archetypes/server.md
+++ b/archetypes/server.md
@@ -4,7 +4,7 @@ date: {{ .Date }}
 draft: false
 mainpage: false
 projectpage: false
-projectslug: ""
-projectname: ""
+projectslug: "server"
+projectname: "WorldWind Server Kit"
 listdescription: ""
 ---

--- a/archetypes/web.md
+++ b/archetypes/web.md
@@ -4,7 +4,7 @@ date: {{ .Date }}
 draft: false
 mainpage: false
 projectpage: false
-projectslug: ""
-projectname: ""
+projectslug: "web"
+projectname: "Web WorldWind"
 listdescription: ""
 ---

--- a/config.yaml
+++ b/config.yaml
@@ -2,3 +2,4 @@ baseURL: "https://worldwind.arc.nasa.gov/"
 languageCode: "en-us"
 title: "NASA World Wind"
 metaDataFormat: "yaml"
+cleanDestinationDir: true

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+baseURL: "https://worldwind.arc.nasa.gov/"
+languageCode: "en-us"
+title: "NASA World Wind"
+metaDataFormat: "yaml"

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 baseURL: "https://worldwind.arc.nasa.gov/"
 languageCode: "en-us"
-title: "NASA World Wind"
+title: "NASA WorldWind"
 metaDataFormat: "yaml"
 cleanDestinationDir: true

--- a/content/android/_index.md
+++ b/content/android/_index.md
@@ -1,13 +1,14 @@
 ---
-title: "World Wind Android"
-date: 2017-06-29T12:12:54-04:00
+title: "WorldWind Android"
+date: 2017-06-30T14:40:16-04:00
 draft: false
 mainpage: false
 projectpage: true
 projectslug: "android"
+projectname: "WorldWind Android"
+listdescription: ""
 ---
 
-## Overview
+### Overview
 
-Example overview/_index.md page of a project.
-
+Some overview on the Android project...

--- a/content/android/_index.md
+++ b/content/android/_index.md
@@ -1,0 +1,13 @@
+---
+title: "World Wind Android"
+date: 2017-06-29T12:12:54-04:00
+draft: false
+mainpage: false
+projectpage: true
+projectslug: "android"
+---
+
+## Overview
+
+Example overview/_index.md page of a project.
+

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta name="description" content="NASA World Wind Software Development Kits (SDKs) for geo-spatial 3D virtual
+        globe visualization via OpenGL/WebGL on Android, Java and JavaScript/HTML5 platforms.">
+        <link rel="icon" href="/img/favicon.ico" type="image/x-icon"/>
+        <title>{{ block "head-title" . }}
+        {{ end }}</title>
+        <link href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.7/spacelab/bootstrap.min.css" rel="stylesheet" integrity="sha384-L/tgI3wSsbb3f/nW9V6Yqlaw3Gj7mpE56LWrhew/c8MIhAYWZ/FNirA64AVkB5pI" crossorigin="anonymous">
+        <link href="/css/theme.css" rel="stylesheet">
+        {{ block "head-block" . }}
+        {{ end }}
+    </head>
+    <body>
+        <!-- Navigation Bar -->     
+        <nav class="navbar navbar-default">
+            <div class="container">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                        <span class="sr-only">Toggle navigation</span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <img class="navbar-brand" src="https://cdn.earthdata.nasa.gov/eui/latest/docs/assets/ed-logos/meatball_hover.png" alt="Meatball" />
+                    <a class="navbar-brand" href="/">NASA World Wind</a>
+                </div>
+                <div id="navbar" class="navbar-collapse collapse">
+                    <ul class="nav navbar-nav navbar-right">
+                        <li><a href="/android">Android</a></li>
+                        <li><a href="/java">Java</a></li>
+                        <li><a href="/web">Web</a></li>
+                        <li><a href="/about">About</a></li>
+                        <li><a href="/contact">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+
+        {{ block "main-block" . }}
+        {{ end }}
+       
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+    </body>
+</html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-        <meta name="description" content="NASA World Wind Software Development Kits (SDKs) for geo-spatial 3D virtual
+        <meta name="description" content="NASA WorldWind Software Development Kits (SDKs) for geo-spatial 3D virtual
         globe visualization via OpenGL/WebGL on Android, Java and JavaScript/HTML5 platforms.">
         <link rel="icon" href="/img/favicon.ico" type="image/x-icon"/>
         <title>{{ block "head-title" . }}
@@ -26,7 +26,7 @@
                         <span class="icon-bar"></span>
                     </button>
                     <img class="navbar-brand" src="https://cdn.earthdata.nasa.gov/eui/latest/docs/assets/ed-logos/meatball_hover.png" alt="Meatball" />
-                    <a class="navbar-brand" href="/">NASA World Wind</a>
+                    <a class="navbar-brand" href="/">NASA WorldWind</a>
                 </div>
                 <div id="navbar" class="navbar-collapse collapse">
                     <ul class="nav navbar-nav navbar-right">

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -1,6 +1,0 @@
-{{ define "head-title" }}
-    NASA World Wind
-{{ end }}
-{{ define "main-block" }}
-    {{ .Content }}
-{{ end }}

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -1,0 +1,6 @@
+{{ define "head-title" }}
+    NASA World Wind
+{{ end }}
+{{ define "main-block" }}
+    {{ .Content }}
+{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,33 @@
+{{ define "head-title" }}
+    {{ if eq .Params.mainpage true }}
+        NASA World Wind
+    {{ else }}
+        NASA World Wind - {{ .Params.Title }}
+    {{ end }}
+{{ end }}
+
+{{ define "main-block" }}
+    {{ if eq .Params.mainpage true }}
+        <!-- The home page goes here -->
+    {{ else if eq .Params.projectpage true }}
+        {{ partial "project-navbar.html" . }}
+        <div class="container">
+            {{ .Content }}
+        </div>
+    {{ else }}   
+        {{ partial "project-navbar.html" . }}
+        <div class="contianer">
+            {{ .Content }}
+            {{ range .Data.Pages.ByTitle }}
+                <div class="panel panel-primary">
+                    <div class="panel-heading">
+                        <a href="{{ .Permalink }}"><h3 class="panel-title">{{ .Params.TutorialName }}</h3></a>
+                    </div>
+                    <div class="panel-body">
+                        {{ .Params.ShortDescription }}
+                    </div>
+                </div>
+            {{ end }}
+        </div>
+    {{ end }}
+{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,10 +1,10 @@
 {{ define "head-title" }}
     {{ if eq .Params.mainpage true }}
-        NASA World Wind
+        NASA WorldWind
     {{ else if gt (len .Params.projectname ) 0 }}
         {{ .Params.projectname }} - {{ .Params.title }}
     {{ else }}
-        NASA World Wind - {{ .Params.Title }}
+        NASA WorldWind - {{ .Params.Title }}
     {{ end }}
 {{ end }}
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,8 @@
 {{ define "head-title" }}
     {{ if eq .Params.mainpage true }}
         NASA World Wind
+    {{ else if gt (len .Params.projectname ) 0 }}
+        {{ .Params.projectname }} - {{ .Params.title }}
     {{ else }}
         NASA World Wind - {{ .Params.Title }}
     {{ end }}
@@ -16,15 +18,15 @@
         </div>
     {{ else }}   
         {{ partial "project-navbar.html" . }}
-        <div class="contianer">
+        <div class="container">
             {{ .Content }}
             {{ range .Data.Pages.ByTitle }}
                 <div class="panel panel-primary">
                     <div class="panel-heading">
-                        <a href="{{ .Permalink }}"><h3 class="panel-title">{{ .Params.TutorialName }}</h3></a>
+                        <a href="{{ .Permalink }}"><h3 class="panel-title">{{ .Params.title }}</h3></a>
                     </div>
                     <div class="panel-body">
-                        {{ .Params.ShortDescription }}
+                        {{ .Params.listdescription }}
                     </div>
                 </div>
             {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,10 +1,18 @@
 {{ define "head-title" }}
-    {{ if eq .Params.mainpage true }}
-        NASA WorldWind
-    {{ else if gt (len .Params.projectname ) 0 }}
-        {{ .Params.projectname }} - {{ .Params.title }}
+    {{ if isset .Params "mainpage" }}
+        {{ if eq .Params.mainpage true}}
+            NASA WorldWind
+        {{ else }}
+            NASA WorldWind - {{ .Params.title }}
+        {{ end }}
+    {{ else if isset .Params "projectname" }}
+        {{ if gt (len .Params.projectname) 0 }}
+            {{ .Params.projectname }} - {{ .Params.title }}
+        {{ else }}
+            NASA WorldWind - {{ .Params.title }}    
+        {{ end }}
     {{ else }}
-        NASA WorldWind - {{ .Params.Title }}
+        NASA WorldWind - {{ .Params.title }}
     {{ end }}
 {{ end }}
 

--- a/layouts/_default/project.html
+++ b/layouts/_default/project.html
@@ -1,0 +1,9 @@
+{{ define "head-title" }}
+    NASA World Wind - {{ .Params.Title }}
+{{ end }}
+{{ define "main-block" }}
+    {{ partial "project-navbar" . }}
+    <div class="container">
+        {{ .Content }}
+    </div>
+{{ end }}

--- a/layouts/_default/project.html
+++ b/layouts/_default/project.html
@@ -1,5 +1,5 @@
 {{ define "head-title" }}
-    NASA World Wind - {{ .Params.Title }}
+    {{ .Params.projectname }} - {{ .Params.Title }}
 {{ end }}
 {{ define "main-block" }}
     {{ partial "project-navbar" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "head-title" }}
-    NASA World Wind - {{ .Params.Title }}
+    NASA World Wind - {{ .Params.Title }}   
 {{ end }}
 {{ define "main-block" }}
     <div class="container">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "head-title" }}
-    NASA World Wind - {{ .Params.Title }}   
+    NASA WorldWind - {{ .Params.Title }}   
 {{ end }}
 {{ define "main-block" }}
     <div class="container">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,8 @@
+{{ define "head-title" }}
+    NASA World Wind - {{ .Params.Title }}
+{{ end }}
+{{ define "main-block" }}
+    <div class="container">
+        {{ .Content }}
+    </div>
+{{ end }}

--- a/layouts/partials/project-navbar.html
+++ b/layouts/partials/project-navbar.html
@@ -1,5 +1,5 @@
 <div class="container">
-    <h1>{{ .Params.title }}</h1>
+    <h2>{{ .Params.projectname }}</h2>
 </div>
 <hr>
 <div class="container">

--- a/layouts/partials/project-navbar.html
+++ b/layouts/partials/project-navbar.html
@@ -1,0 +1,27 @@
+<div class="container">
+    <h1>{{ .Params.title }}</h1>
+</div>
+<hr>
+<div class="container">
+    <div class="row row-centered">            
+        <div class="col-xs-6 col-centered col-max">
+            <a href="/{{ .Params.projectSlug }}">Overview</a>
+        </div>
+        <div class="col-xs-6 col-centered col-max">
+            <a href="/{{ .Params.projectSlug }}/get-started/">Get Started</a>
+        </div>
+        <div class="col-xs-6 col-centered col-max">
+            <a href="/{{ .Params.projectSlug }}/developer-guide/">Developer Guide</a>
+        </div>
+        <div class="col-xs-6 col-centered col-max">
+            <a href="/{{ .Params.projectSlug }}/tutorials/">Tutorials</a>
+        </div>
+        <div class="col-xs-6 col-centered col-max">
+            <a href="/{{ .Params.projectSlug }}/examples/">Examples</a>
+        </div>
+        <div class="col-xs-6 col-centered col-max">
+            <a href="/{{ .Params.projectSlug }}/docs/">Docs</a>
+        </div>
+    </div>
+</div>
+<hr>

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,19 @@
+/* 
+ Styles below from: http://www.minimit.com/articles/solutions-tutorials/bootstrap-3-responsive-centered-columns
+ */
+/* centered columns styles */
+.row-centered {
+    text-align:center;
+}
+.col-centered {
+    display:inline-block;
+    float:none;
+    /* reset the text-align */
+    text-align:center;
+    /* inline-block space fix */
+    margin-right:-4px;
+}
+.col-max {
+    /* custom max width */
+    max-width:150px;
+}


### PR DESCRIPTION
This closes #10 by initializing the Hugo project and specifying some default html templates.

[Hugo uses golang's html template engine](https://gohugo.io/templates/overview/). I've defined a `baseof.html` [block template](https://gohugo.io/templates/blocks/) which all other full page templates utilize. The `list.html` and `single.html` are the default templates used by Hugo for most pages. The `project.html` template is similar to `single.html`, except that it adds the [partial template](https://gohugo.io/templates/partials/) `project-navbar.html` which adds project specific pages to a page.

The css framework is Bootstrap with a free, CDN hosted theme [Spacelab](https://bootswatch.com/spacelab/). There is a `theme.css` extension in the `static/css` directory which provides some additional functionality.

This pr also includes the `_index.md` file in the Android project content directory. The actual content isn't there, but this will allow you to visualize the site locally. Just: `hugo serve` and navigate to the [Android Project](http://localhost:1313/android/). Since the `_index.md` file is the only content file, the http://localhost:1313/android/ is the only page that will work.
