### PR TITLE
Enable CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# Directs the Travis CI build service for Hugo based WorldWind website
+# For more information see https://docs.travis-ci.com/user/customizing-the-build/
+
+# Download Hugo and extract the system /tmp directory
+before_script:
+ - curl -OL "https://github.com/gohugoio/hugo/releases/download/v0.24.1/hugo_0.24.1_Linux-64bit.tar.gz"
+ - tar -xvf hugo_0.24.1_Linux-64bit.tar.gz -C /tmp/
+
+# Blacklist the master branch to prevent builds kicked off by travis pushes
+branches:
+  except:
+    - master
+
+# Build the website - queries Bintray and OJO APIs for latest version information
+script:
+ - /tmp/hugo --verbose

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,10 +1,6 @@
 {{ define "head-title" }}
-    {{ if isset .Params "mainpage" }}
-        {{ if eq .Params.mainpage true}}
-            NASA WorldWind
-        {{ else }}
-            NASA WorldWind - {{ .Params.title }}
-        {{ end }}
+    {{ if eq .Params.mainpage true}}
+        NASA WorldWind
     {{ else if isset .Params "projectname" }}
         {{ if gt (len .Params.projectname) 0 }}
             {{ .Params.projectname }} - {{ .Params.title }}


### PR DESCRIPTION
This is a resubmission of #39 after noticing the commit history on #39 seemed to include previously merged commits. I've closed #39. I also reduced the nil checks after reading some documentation and conducting a few tests.

This pull request partially addresses #12, specifically enabling basic CI, but **not** deployment. Including this check will help keep code quality high while main site content is populated.

This closes #22 Build common infrastructure. #22 only specifies limited CI processes to satisfy the epic.

In addition to merging this pull request, Travis functionality must be enabled on travis-ci.org.