### PR TITLE
Add webworldwind.org overview and features content

### DIFF
--- a/content/web/_index.md
+++ b/content/web/_index.md
@@ -1,0 +1,53 @@
+---
+title: "Web WorldWind"
+date: 2017-07-16T21:40:51-05:00
+draft: false
+mainpage: false
+projectpage: true
+projectslug: "web"
+projectname: "Web WorldWind"
+listdescription: ""
+---
+
+## Get Started
+
+Web WorldWind is a 3D virtual globe API for HTML5 and JavaScript. Web pages include Web WorldWind to provide one or more virtual globes on that page. The [European Space Agency](https://www.esa.int/) is now partnering with NASA on development. Work on Web WorldWind began in 2014 and is very active today.
+
+---
+
+## Download
+
+*The first release of Web WorldWind is imminent, please check back soon for updates to these instructions! The versioned release will be the first official release of Web WorldWind and will be available as a hosted library and through NPM.*
+
+To add Web WorldWind to your web application, build the worldwind.js and worldwind.min.js files locally and host the the library in a manner which best supports your applications requirements. To build the worldwind.js and worldwind.min.js files in your own environment follow the directions in the [HowToBuildWebWW](https://github.com/NASAWorldWind/WebWorldWind/blob/develop/HowToBuildWebWW.md) document in the repository.
+
+For more information about integrating Web WorldWind with your site and for how to use its many features, please see the [Developer Guide](/web/developer-guide/).
+
+---
+
+## Features
+
+Web WorldWind is a free, open-source virtual globe for web pages. Written in JavaScript, Web WorldWind enables web page and web application builders to quickly create interactive visualizations of geographic information on an interactive 3D globe or 2D map. Web WorldWind provides an API that enables JavaScript programs to control every detail of visualization and interaction. Web WorldWind runs on all major operating systems, desktop and mobile devices, and web browsers.
+
+Web WorldWind provides a rich set of features for displaying and interacting with geographic information. Because Web WorldWind is completely open-source and designed to be extensible, extending the API and functionality is simple and easy to do.
+
+### General Features
+
+- Open-source, high-performance, 3D virtual globe (WGS84) for web pages and web applications
+- 2D Map mode with selectable and extensible map projections
+- JavaScript API for automating all aspects of interaction and visualization
+- Large collection of built-in high-resolution imagery and terrain
+- Display high-resolution imagery, terrain and geographic data from any public or private source
+- Supports REST, WMS and Bing
+- Large collection of geometric and geographic shapes for representing information
+- Navigation and Viewing, Picking
+- Display multiple globes and maps on the same page
+- Simple to use, extend and modify
+
+### Graphics Capabilities
+
+- Placemark, Path and Curtain, Polygon and Extruded Polygon, Text
+- Terrain conforming shapes: Path, Polygon, Ellipse, Circle, Quadrilateral, Square
+- Imagery: JPEG, PNG
+- Graticules
+- Shapefiles


### PR DESCRIPTION
This pull request closes #28 by porting the Overview and Features content from webworldwind.org.

Most of the content is ported word for word; however, there is a special **Download** section which makes a general note of how to build the library locally as the repository is setup now in the develop branch. Additionally, I've added content which makes reference to the upcoming release and NPM inclusion.

This effort supports the #14 Port external site content epic.