### PR TITLE
Change spelling for "World Wind" and "World Window"

### DIFF
--- a/content/android/tutorials/basic-globe.md
+++ b/content/android/tutorials/basic-globe.md
@@ -20,7 +20,7 @@ listimage: "/img/ww-android-basic-globe.png"
 It’s very easy to get started using WorldWind Android. You simply create and configure a WorldWindow View object and add it to a layout. This can be performed in an Activity or a Fragment. The following snippet shows the code that creates the WorldWindow and adds some imagery to the globe.
 
 ```java
-// Create a World Window (a GLSurfaceView)...
+// Create a WorldWindow (a GLSurfaceView)...
 WorldWindow wwd = new WorldWindow(getContext());
 // ... and add some map layers
 wwd.getLayers().addLayer(new BackgroundLayer());
@@ -51,9 +51,9 @@ public class BasicGlobeFragment extends Fragment {
      * Creates a new WorldWindow (GLSurfaceView) object.
      */
     public WorldWindow createWorldWindow() {
-        // Create the World Window (a GLSurfaceView) which displays the globe.
+        // Create the WorldWindow (a GLSurfaceView) which displays the globe.
         this.wwd = new WorldWindow(getContext());
-        // Setup the World Window's layers.
+        // Setup the WorldWindow's layers.
         this.wwd.getLayers().addLayer(new BackgroundLayer());
         this.wwd.getLayers().addLayer(new BlueMarbleLandsatLayer());
         return this.wwd;

--- a/content/android/tutorials/basic-ww-app.md
+++ b/content/android/tutorials/basic-ww-app.md
@@ -60,7 +60,7 @@ This tutorial sets up a project from scratch and inserts a WorldWind globe in a 
     ```
     Second, create an instance of a WorldWindow in MainActivity.java and attach to the FrameLayout. The following code snippet should be added to the MainActivity's onCreate() method.
     ```java
-    // Create a World Window (a GLSurfaceView)...
+    // Create a WorldWindow (a GLSurfaceView)...
     WorldWindow wwd = new WorldWindow(getApplicationContext());
     // ... and add some map layers
     wwd.getLayers().addLayer(new BackgroundLayer());
@@ -119,7 +119,7 @@ This tutorial sets up a project from scratch and inserts a WorldWind globe in a 
             super.onCreate(savedInstanceState);
             setContentView(R.layout.activity_main);
 
-            // Create a World Window (a GLSurfaceView)...
+            // Create a WorldWindow (a GLSurfaceView)...
             WorldWindow wwd = new WorldWindow(getApplicationContext());
             // ... and add some map layers
             wwd.getLayers().addLayer(new BackgroundLayer());

--- a/content/android/tutorials/geopackage.md
+++ b/content/android/tutorials/geopackage.md
@@ -42,7 +42,7 @@ public class GeoPackageFragment extends BasicGlobeFragment {
             new LayerFactory.Callback() {
                 @Override
                 public void creationSucceeded(LayerFactory factory, Layer layer) {
-                    // Add the finished GeoPackage layer to the World Window.
+                    // Add the finished GeoPackage layer to the WorldWindow.
                     getWorldWindow().getLayers().addLayer(layer);
                     // Place the viewer directly over the GeoPackage image.
                     getWorldWindow().getNavigator().setLatitude(36.8139677556754);

--- a/content/android/tutorials/navigator-events.md
+++ b/content/android/tutorials/navigator-events.md
@@ -63,7 +63,7 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
         this.animatorSet = new AnimatorSet();
         this.animatorSet.play(fadeOut);
 
-        // Create a simple Navigator Listener that logs navigator events emitted by the World Window.
+        // Create a simple Navigator Listener that logs navigator events emitted by the WorldWindow.
         NavigatorListener listener = new NavigatorListener() {
             @Override
             public void onNavigatorEvent(WorldWindow wwd, NavigatorEvent event) {
@@ -96,7 +96,7 @@ public class NavigatorEventFragment extends BasicGlobeFragment {
             }
         };
 
-        // Register the Navigator Listener with the activity's World Window.
+        // Register the Navigator Listener with the activity's WorldWindow.
         this.getWorldWindow().addNavigatorListener(listener);
 
         return rootView;

--- a/content/android/tutorials/placemark-picking.md
+++ b/content/android/tutorials/placemark-picking.md
@@ -33,7 +33,7 @@ public class PlacemarksPickingFragment extends BasicGlobeFragment {
         // Let the super class (BasicGlobeFragment) do the creation
         WorldWindow wwd = super.createWorldWindow();
 
-        // Override the World Window's built-in navigation behavior by adding picking support.
+        // Override the WorldWindow's built-in navigation behavior by adding picking support.
         wwd.setWorldWindowController(new PickNavigateController());
 
         // Add a layer for placemarks to the WorldWindow

--- a/content/android/tutorials/surface-image.md
+++ b/content/android/tutorials/surface-image.md
@@ -40,7 +40,7 @@ public class SurfaceImageFragment extends BasicGlobeFragment {
         String urlString = "http://worldwindserver.net/android/images/etna.jpg";
         SurfaceImage surfaceImageUrl = new SurfaceImage(sector, ImageSource.fromUrl(urlString));
 
-        // Add a World Window layer that displays the Surface Image, just before the Atmosphere layer.
+        // Add a WorldWindow layer that displays the Surface Image, just before the Atmosphere layer.
         RenderableLayer layer = new RenderableLayer("Surface Image");
         layer.addRenderable(surfaceImageResource);
         layer.addRenderable(surfaceImageUrl);

--- a/content/android/tutorials/wms-layer.md
+++ b/content/android/tutorials/wms-layer.md
@@ -39,7 +39,7 @@ public class WmsLayerFragment extends BasicGlobeFragment {
         config.layerNames = "MYD28M"; // Sea surface temperature (MODIS)
         WmsLayer layer = new WmsLayer(new Sector().setFullSphere(), 1e3, config); // 1km resolution
 
-        // Add the WMS layer to the World Window.
+        // Add the WMS layer to the WorldWindow.
         wwd.getLayers().addLayer(layer);
 
         return wwd;

--- a/content/android/tutorials/wmts-layer.md
+++ b/content/android/tutorials/wmts-layer.md
@@ -40,7 +40,7 @@ public class WmtsLayerFragment extends BasicGlobeFragment {
             new LayerFactory.Callback() {
                 @Override
                 public void creationSucceeded(LayerFactory factory, Layer layer) {
-                    // Add the finished WMTS layer to the World Window.
+                    // Add the finished WMTS layer to the WorldWindow.
                     getWorldWindow().getLayers().addLayer(layer);
                     Log.i("gov.nasa.worldwind", "WMTS layer creation succeeded");
                 }

--- a/content/java/_index.md
+++ b/content/java/_index.md
@@ -8,8 +8,8 @@ draft: false
 
 Looking for Web WorldWind or WorldWind Android? See https://worldwind.arc.nasa.gov.
 
-- [Get Started](/java/get-started/) shows you how to download and run World Wind
-- [Features](/java/features/) describes World Wind’s capabilities
+- [Get Started](/java/get-started/) shows you how to download and run WorldWind
+- [Features](/java/features/) describes WorldWind’s capabilities
 - [Demos](/java/demos/) showcases WorldWind applications and applets
 - [Examples](/java/examples) presents over 90 WorldWind example programs and applets
 - [Common Problems](/java/tutorials/common-problems/) gives solutions to typical programming problems

--- a/content/java/examples.md
+++ b/content/java/examples.md
@@ -32,7 +32,7 @@ Below are brief descriptions of selected example programs.  All examples can be 
 
 **ApplicationTemplate** -  Provides a base application framework for simple WorldWind examples.
 
-**Shutdown** -  Shows how to shut down a WorldWindow and how to shut down all of World Wind.
+**Shutdown** -  Shows how to shut down a WorldWindow and how to shut down all of WorldWind.
 
 ### Layers
 
@@ -68,11 +68,11 @@ Below are brief descriptions of selected example programs.  All examples can be 
 
 **DataInstallerAp** - Provides an interactive means to install data on the client.
 
-**Shapefiles** -  Illustrates how to import ESRI Shapefiles into World Wind.
+**Shapefiles** -  Illustrates how to import ESRI Shapefiles into WorldWind.
 
 **ExtrudedPolygonsFromShapefile** -  Shows how to load extruded shapes from Shapefiles.
 
-**VPFLayerDemo** -  Illustrates how to import data from a Vector Product Format (VPF) database into World Wind.
+**VPFLayerDemo** -  Illustrates how to import data from a Vector Product Format (VPF) database into WorldWind.
 
 **FlatWorldEartquakes** -  Demonstrates how to use the EarthFlat and FlatOrbitView to display USGS’ latest earthquakes RSS feed.
 
@@ -152,7 +152,7 @@ Below are brief descriptions of selected example programs.  All examples can be 
 
 **WebBrowserBalloons** -  Illustrates how to use WorldWind browser balloons to display HTML, JavaScript, and Flash content to the user in the form of a screen-aligned balloon.
 
-**TacticalGraphics and TacticalSymbol** - Shows examples of World Wind’s 2525C implementation.
+**TacticalGraphics and TacticalSymbol** - Shows examples of WorldWind’s 2525C implementation.
 
 **Markers** -  Displays Markers (small shapes) in different shapes and colors.
 
@@ -204,7 +204,7 @@ Below are brief descriptions of selected example programs.  All examples can be 
 
 **FlatWorld** -  Demonstrates how to display a flat globe instead of a round globe.
 
-**ConfiguringGLRuntimeCapabilities** -  Illustrates how to configure World Wind’s OpenGL features using a GLRuntimeCapabilities.
+**ConfiguringGLRuntimeCapabilities** -  Illustrates how to configure WorldWind’s OpenGL features using a GLRuntimeCapabilities.
 
 **CustomElevationModel** -  Illustrates how to configure WorldWind with a custom ElevationModel from a configuration file.
 
@@ -238,13 +238,13 @@ Below are brief descriptions of selected example programs.  All examples can be 
 
 **MeasureToolUsage** -  Shows how to use the MeasureTool to draw a shape on the globe and measure length, area, etc.
 
-**GazeteerApp** -  Shows how to integrate a gazetteer search function into the World Window using the YahooGazetteer.
+**GazeteerApp** -  Shows how to integrate a gazetteer search function into the WorldWindow using the YahooGazetteer.
 
 **DataCacheViewer** -  Shows how to build a tool to allow the user to view and delete cached WorldWind files based on how old they are.
 
 ### Multiwindow
 
-**MultiFrame** -  Shows how to create two World Windows, each in its own JFrame. The World Windows share a globe and some layers.
+**MultiFrame** -  Shows how to create two WorldWindows, each in its own JFrame. The WorldWindows share a globe and some layers.
 
 **CardLayoutUsage** -  Illustrates how to use multiple WorldWind windows with a CardLayout layer manager.
 

--- a/content/java/get-started.md
+++ b/content/java/get-started.md
@@ -6,7 +6,7 @@ draft: false
 
 ## Get Started
 
-WorldWind is an SDK (software development kit) that software engineers can use to build their own applications. To run a WorldWind demo application, visit the [Demos](/java/demos/) page. Follow these instructions to download, run, and deploy an application using World Wind.
+WorldWind is an SDK (software development kit) that software engineers can use to build their own applications. To run a WorldWind demo application, visit the [Demos](/java/demos/) page. Follow these instructions to download, run, and deploy an application using WorldWind.
 
 ---
 

--- a/content/java/releases.md
+++ b/content/java/releases.md
@@ -18,11 +18,11 @@ With the release of v2.1.0 all NASA WorldWind map services (imagery, terrain, pl
 
 2.0.0 differs from release 1.5.1 primarily in its use of JOGL 2 vs. 1.5.1’s use of JOGL 1.
 
-Note: JOGL 2 performs runtime extraction of native binaries. Some deployment situations may not allow this because it extracts the binaries to the application user’s temp directory. Runtime extraction can be avoided by following the instructions in World Wind’s README.txt file in the “New features and improvements in WorldWind Java SDK 2.0.0” section.
+Note: JOGL 2 performs runtime extraction of native binaries. Some deployment situations may not allow this because it extracts the binaries to the application user’s temp directory. Runtime extraction can be avoided by following the instructions in WorldWind’s README.txt file in the “New features and improvements in WorldWind Java SDK 2.0.0” section.
 
 ### Release 1.5.1, July 24, 2013
 
-This release is a patch for Release 1.5 that repairs a geo-referencing issue with World Wind’s DTED elevation importer. See the release’s README.txt file for a complete list of changes.
+This release is a patch for Release 1.5 that repairs a geo-referencing issue with WorldWind’s DTED elevation importer. See the release’s README.txt file for a complete list of changes.
 
 Note: The changes made for Release 1.5.1 have also been applied to the WorldWind 2.0 Current Development Release.
 
@@ -40,7 +40,7 @@ This release adds support for Mil-Std 2525C and the KML NetworkLinkControl eleme
 
 ### Release 1.2, July 19, 2011
 
-This is World Wind’s first public formal release. It’s undergone significant testing and contains important documentation that was missing from the previous “pre-alpha” daily releases. It also initiates a portal — this site — that gathers into one place all information relative to understanding and using WorldWind and its API.
+This is WorldWind’s first public formal release. It’s undergone significant testing and contains important documentation that was missing from the previous “pre-alpha” daily releases. It also initiates a portal — this site — that gathers into one place all information relative to understanding and using WorldWind and its API.
 
 This release of WorldWind operates on all platforms WorldWind has historically supported: OS X, Windows 32 & 64, Linux 32 & 64. It is expected to work on Solaris but has not been tested on that platform.
 

--- a/content/web/_index.md
+++ b/content/web/_index.md
@@ -8,9 +8,9 @@ draft: false
 
 Web WorldWind is a 3D virtual globe API for HTML5 and JavaScript. Web pages include Web WorldWind to provide one or more virtual globes on that page.  The European Space Agency is now partnering with NASA on development.
 
-- [Get Started](/web/get-started/) shows how to use Web World Wind
-- [Features](/web/features/) describes Web World Wind’s capabilities
-- [Examples](/web/examples/) presents Web World Wind’s example code
+- [Get Started](/web/get-started/) shows how to use Web WorldWind
+- [Features](/web/features/) describes Web WorldWind’s capabilities
+- [Examples](/web/examples/) presents Web WorldWind’s example code
 - [Common Problems](/web/tutorials/common-problems/) gives solution to typical problems
 - [Tutorials](/web/tutorials/) explains Web WorldWind in depth
 

--- a/content/web/get-started.md
+++ b/content/web/get-started.md
@@ -6,11 +6,11 @@ draft: false
 
 ## Get Started
 
-It’s very easy to get started using Web World Wind. There’s nothing to download. You simply include a short script in an HTML page, as in this example:
+It’s very easy to get started using Web WorldWind. There’s nothing to download. You simply include a short script in an HTML page, as in this example:
 
 ```html
 <!DOCTYPE html>
-<!-- This is a very simple example of using Web World Wind. -->
+<!-- This is a very simple example of using Web WorldWind. -->
 <html>
 <head lang="en">
     <meta charset="UTF-8">
@@ -20,7 +20,7 @@ It’s very easy to get started using Web World Wind. There’s nothing to downl
 </head>
 <body>
 <div style="position: absolute; top: 50px; left: 50px;">
-    <!-- Create a canvas for Web World Wind. -->
+    <!-- Create a canvas for Web WorldWind. -->
     <canvas id="canvasOne" width="1024" height="768">
         Your browser does not support HTML5 Canvas.
     </canvas>
@@ -29,16 +29,16 @@ It’s very easy to get started using Web World Wind. There’s nothing to downl
     // Register an event listener to be called when the page is loaded.
     window.addEventListener("load", eventWindowLoaded, false);
 
-    // Define the event listener to initialize Web World Wind.
+    // Define the event listener to initialize Web WorldWind.
     function eventWindowLoaded() {
-        // Create a World Window for the canvas.
+        // Create a WorldWindow for the canvas.
         var wwd = new WorldWind.WorldWindow("canvasOne");
 
-        // Add some image layers to the World Window's globe.
+        // Add some image layers to the WorldWindow's globe.
         wwd.addLayer(new WorldWind.BMNGOneImageLayer());
         wwd.addLayer(new WorldWind.BingAerialWithLabelsLayer());
 
-        // Add a compass, a coordinates display and some view controls to the World Window.
+        // Add a compass, a coordinates display and some view controls to the WorldWindow.
         wwd.addLayer(new WorldWind.CompassLayer());
         wwd.addLayer(new WorldWind.CoordinatesDisplayLayer(wwd));
         wwd.addLayer(new WorldWind.ViewControlsLayer(wwd));
@@ -48,8 +48,8 @@ It’s very easy to get started using Web World Wind. There’s nothing to downl
 </html>
 ```
 
-This example first includes the Web WorldWind library, worldwindlib.js, then creates an HTML5 canvas, then defines a script that creates the World Window and populates it with two image layers and three control layers. Click this link to see the web page it creates in a new window. The page contains an interactive 3D virtual globe. Try zooming in with your mouse wheel or on a mobile device with a pinch gesture. Drag the mouse or your finger to pan around the globe. Drag the right mouse button or your two fingers upward to tilt the globe.
+This example first includes the Web WorldWind library, worldwindlib.js, then creates an HTML5 canvas, then defines a script that creates the WorldWindow and populates it with two image layers and three control layers. Click this link to see the web page it creates in a new window. The page contains an interactive 3D virtual globe. Try zooming in with your mouse wheel or on a mobile device with a pinch gesture. Drag the mouse or your finger to pan around the globe. Drag the right mouse button or your two fingers upward to tilt the globe.
 
-Web WorldWind provides much more functionality than is available in this simple example. The Examples page illustrates much of that functionality in simple examples. The Developer’s Guide describes Web World Wind’s functionality in detail. The Deployments page explains how to deploy Web WorldWind at  your own web site.
+Web WorldWind provides much more functionality than is available in this simple example. The Examples page illustrates much of that functionality in simple examples. The Developer’s Guide describes Web WorldWind’s functionality in detail. The Deployments page explains how to deploy Web WorldWind at  your own web site.
 
 If you need help, see the resources listed on the Home page, especially the Web WorldWind forum.

--- a/content/web/tutorials/concepts.md
+++ b/content/web/tutorials/concepts.md
@@ -11,28 +11,28 @@ Web WorldWind is a virtual globe component that you embed in web pages. It provi
 
 ![Example Web WorldWind Page](/img/web/layout.jpg)
 
-The Web WorldWind component is called a World Window. The web page may contain more than one World Window. Each operates independently of the others. The World Window is the primary object the application interacts with.
+The Web WorldWind component is called a WorldWindow. The web page may contain more than one WorldWindow. Each operates independently of the others. The WorldWindow is the primary object the application interacts with.
 
-### The World Window
+### The WorldWindow
 
-The following figure illustrates Web World Wind’s overall architecture. Objects in red are objects the app typically interacts with, in addition to the World Window. Items in cyan represent objects that work behind the scenes to retrieve data from the internet and create what the user sees.
+The following figure illustrates Web WorldWind’s overall architecture. Objects in red are objects the app typically interacts with, in addition to the WorldWindow. Items in cyan represent objects that work behind the scenes to retrieve data from the internet and create what the user sees.
 
 ![Web WorldWind Architecture](/img/web/architecture1.jpg)
 
-The World Window object encapsulates the Web WorldWind functionality around an HTML canvas. The canvas is created by the app, typically within a <div> element in an HTML page. It’s ID is passed to WorldWind during construction of a WorldWindow object. An app (web page) may contain more than one WorldWindow object, each for a different canvas.
+The WorldWindow object encapsulates the Web WorldWind functionality around an HTML canvas. The canvas is created by the app, typically within a <div> element in an HTML page. It’s ID is passed to WorldWind during construction of a WorldWindow object. An app (web page) may contain more than one WorldWindow object, each for a different canvas.
 
-In addition to acting as a container for the Globe and other objects, the World Window provides picking and scene control. See the World Window chapter of this developer’s guide for more information about it. Also see the World Window API documentation for its interface details.
+In addition to acting as a container for the Globe and other objects, the WorldWindow provides picking and scene control. See the WorldWindow chapter of this developer’s guide for more information about it. Also see the WorldWindow API documentation for its interface details.
 
 ### Layers
 
-Aside from the World Window, the most fundamental objects in Web WorldWind are layers. Layers contain all the information displayed in the World Window. All imagery, shapes and decorations such as the compass are defined in layers.
+Aside from the WorldWindow, the most fundamental objects in Web WorldWind are layers. Layers contain all the information displayed in the WorldWindow. All imagery, shapes and decorations such as the compass are defined in layers.
 
-Each World Window contains one Layer List, which holds all the layers displayed in that World Window. When the World Window draws the scene, it traverses its layer list in order and draws the imagery and other content listed there.
+Each WorldWindow contains one Layer List, which holds all the layers displayed in that WorldWindow. When the WorldWindow draws the scene, it traverses its layer list in order and draws the imagery and other content listed there.
 
-Typically a layer list includes imagery layers followed by shape layers followed by decoration layers. The World Window’s layer list is empty by default. The first thing a Web WorldWind application must do is add layers to the layer list. You can see this in all the Web WorldWind examples. Here’s an example of adding initial imagery layers along with a compass, a coordinates display and view controls:
+Typically a layer list includes imagery layers followed by shape layers followed by decoration layers. The WorldWindow’s layer list is empty by default. The first thing a Web WorldWind application must do is add layers to the layer list. You can see this in all the Web WorldWind examples. Here’s an example of adding initial imagery layers along with a compass, a coordinates display and view controls:
 
 ```javascript
-// Create the World Window.
+// Create the WorldWindow.
 var wwd = new WorldWind.WorldWindow("canvasOne");
 
 // Create and add imagery layers.
@@ -49,23 +49,23 @@ See the [Layers](/web/tutorials/layers/) section of the tutorials for lots more 
 
 ### Shapes
 
-Shapes represent information that you want to display on or relative to the globe. They can be simple placemarks, complex volumes or shapes draped on the terrain. All shapes are contained in layers and the layers contained in a World Window’s layer list. Web WorldWind provides many different kinds of shapes. See the [Shapes](/web/tutorials/shapes/) tutorial for a listing and complete description of Web World Wind’s shapes.
+Shapes represent information that you want to display on or relative to the globe. They can be simple placemarks, complex volumes or shapes draped on the terrain. All shapes are contained in layers and the layers contained in a WorldWindow’s layer list. Web WorldWind provides many different kinds of shapes. See the [Shapes](/web/tutorials/shapes/) tutorial for a listing and complete description of Web WorldWind’s shapes.
 
 ### Globe
 
 The Globe is responsible for representing the WGS84 ellipsoid and its terrain. It also handles implementation of the various 2D projections that can be utilized instead of the 3D globe. Aside from selecting these projections, the application does not typically interact with the globe. The exception is when the application desires to know terrain elevations, such as when performing line-of-sight calculations, or when it needs to convert between geographic and Cartesian coordinates. See the API documentation for Globe and Globe2D to learn more about the Globe object.
 
-Each World Window has one Globe, created automatically when the World Window is created. The application may replace this globe with another. Most Web WorldWind examples replace the globe with a 2D, flat globe when the user selects a 2D projection.
+Each WorldWindow has one Globe, created automatically when the WorldWindow is created. The application may replace this globe with another. Most Web WorldWind examples replace the globe with a 2D, flat globe when the user selects a 2D projection.
 
 ### Navigator
 
 The Navigator is responsible for converting user actions to manipulations of the globe. It monitors mouse events and user gestures and translates them to pan, zoom or tilt operations on the globe. The Navigator can also be driven by the application to move the view to a particular location or to set its tilt and heading.
 
-Each World Window has its own Navigator, which is created automatically when the World Window is created. The application may subsequently replace this Navigator, perhaps with one the app developer created to operate differently or in response to different gestures.
+Each WorldWindow has its own Navigator, which is created automatically when the WorldWindow is created. The application may subsequently replace this Navigator, perhaps with one the app developer created to operate differently or in response to different gestures.
 
 ### Other Objects
 
-The above objects — World Window, Layers, Shapes, Globe, Navigator — are the objects that applications typically interact with. Web WorldWind contains many other objects, most of which operate behind the scenes without any direction needed from the application. This includes those objects that automatically retrieve data such as imagery and elevations from the internet. Applications may interact with these objects to achieve non-default behavior, but doing so is not necessary.
+The above objects — WorldWindow, Layers, Shapes, Globe, Navigator — are the objects that applications typically interact with. Web WorldWind contains many other objects, most of which operate behind the scenes without any direction needed from the application. This includes those objects that automatically retrieve data such as imagery and elevations from the internet. Applications may interact with these objects to achieve non-default behavior, but doing so is not necessary.
 
 ### Extensibility
 

--- a/content/web/tutorials/event-and-gesture-handling.md
+++ b/content/web/tutorials/event-and-gesture-handling.md
@@ -7,9 +7,9 @@ listdescription: "How to manage cursor or tactile input."
 
 ## Event and Gesture Handling
 
-Applications can generally monitor and respond to JavaScript events as they normally would. But because the World Window’s navigator is monitoring mouse and touch events to enable the user to manipulate the globe, some coordination between the application’s event handling and the navigator’s event handling is necessary. Web WorldWind does not monitor keyboard events, so no coordination is necessary for those.
+Applications can generally monitor and respond to JavaScript events as they normally would. But because the WorldWindow’s navigator is monitoring mouse and touch events to enable the user to manipulate the globe, some coordination between the application’s event handling and the navigator’s event handling is necessary. Web WorldWind does not monitor keyboard events, so no coordination is necessary for those.
 
-If your application is to work on conventional and mobile devices, it should monitor both mouse events and gestures if it wants to respond to user input beyond what the World Window’s navigator already does. Web WorldWind examples such as PlacemarksAndPicking.js and GoToLocation.js do this.
+If your application is to work on conventional and mobile devices, it should monitor both mouse events and gestures if it wants to respond to user input beyond what the WorldWindow’s navigator already does. Web WorldWind examples such as PlacemarksAndPicking.js and GoToLocation.js do this.
 
 ### Monitoring Mouse Events
 

--- a/content/web/tutorials/layers.md
+++ b/content/web/tutorials/layers.md
@@ -7,12 +7,12 @@ listdescription: "WorldWind's primary content display container."
 
 ## Layers
 
-<img src="/img/web/layerlist.jpg" class="img-responsive" align="right">LayerListLayers hold all the information displayed by the World Window. Each World Window holds one layer list that contains all the layers to display in that World Window. Each layer contains either imagery, shapes or decorations such as a compass. During rendering, layers are displayed in the order they’re defined in the layer list. (3D shapes within layers, however, are displayed in far-to-near order, as described in the Shapes section.) The adjacent illustration depicts six layers. The first two are image layers. The second two hold shapes. And the bottom two hold decorations.
+<img src="/img/web/layerlist.jpg" class="img-responsive" align="right">LayerListLayers hold all the information displayed by the WorldWindow. Each WorldWindow holds one layer list that contains all the layers to display in that WorldWindow. Each layer contains either imagery, shapes or decorations such as a compass. During rendering, layers are displayed in the order they’re defined in the layer list. (3D shapes within layers, however, are displayed in far-to-near order, as described in the Shapes section.) The adjacent illustration depicts six layers. The first two are image layers. The second two hold shapes. And the bottom two hold decorations.
 
-The above layer list is defined and the layers added to the World Window by the following code:
+The above layer list is defined and the layers added to the WorldWindow by the following code:
 
 ```javascript
-// Create the World Window.
+// Create the WorldWindow.
 var wwd = new WorldWind.WorldWindow("canvasOne");
 
 // Create and add imagery layers.
@@ -73,7 +73,7 @@ placemarkLayer.addRenderable(placemark);
 
 Here the layer is given the display name “Placemarks”.
 
-You must also add the renderable layer to the World Window’s layer list:
+You must also add the renderable layer to the WorldWindow’s layer list:
 
 ```javascript
 wwd.addLayer(placemarkLayer);

--- a/content/web/tutorials/navigation-and-viewing.md
+++ b/content/web/tutorials/navigation-and-viewing.md
@@ -7,18 +7,18 @@ listdescription: "Positioning and orienting the view."
 
 ## Navigation and Viewing
 
-As the user interacts with the globe, panning, zooming and tilting, it’s the World Window’s Navigator that translates the user’s movements into operations on the globe. Each World Window has one navigator. That navigator is responsible for the view onto the globe. A navigator is created automatically when you create a WorldWindow.
+As the user interacts with the globe, panning, zooming and tilting, it’s the WorldWindow’s Navigator that translates the user’s movements into operations on the globe. Each WorldWindow has one navigator. That navigator is responsible for the view onto the globe. A navigator is created automatically when you create a WorldWindow.
 
 Topics on this page:
 
-- [Controlling the View from the World Window](#controlling-view)
+- [Controlling the View from the WorldWindow](#controlling-view)
 - [Controlling the Navigator](#controlling-navigator)
 - [GoTo Animator](#goto)
 - [Geocoders](#geocoders)
 
-### <a name="controlling-view"></a>Controlling the View from the World Window
+### <a name="controlling-view"></a>Controlling the View from the WorldWindow
 
-If all you want to do is move the view to a geographic location or position (a location with altitude), you can use the goTo function of WorldWindow to do that. The GoToLocation example does this. You can directly modify the properties of the World Window’s GoToAnimator to change the go-to travel time or update frequency, or to cancel a previously requested go-to request.
+If all you want to do is move the view to a geographic location or position (a location with altitude), you can use the goTo function of WorldWindow to do that. The GoToLocation example does this. You can directly modify the properties of the WorldWindow’s GoToAnimator to change the go-to travel time or update frequency, or to cancel a previously requested go-to request.
 
 ### <a name="controlling-navigator"></a>Controlling the Navigator
 
@@ -32,16 +32,16 @@ The navigator has two primary properties allowing control:
 By specifying these properties the app can move the user to any point around the globe, as in this example:
 
 ```javascript
-// Get a reference to the World Window.
+// Get a reference to the WorldWindow.
 var wwd = ...
 
 // Adjust the Navigator to place Alaska in the center of the
-// World Window.
+// WorldWindow.
 wwd.navigator.lookAtLocation.latitude = 65;
 wwd.navigator.lookAtLocation.longitude = -150;
 wwd.navigator.range = 2e6; // 2 million meters above the ellipsoid
 
-// Redraw the World Window.
+// Redraw the WorldWindow.
 wwd.redraw();
 ```
 

--- a/content/web/tutorials/picking.md
+++ b/content/web/tutorials/picking.md
@@ -7,7 +7,7 @@ listdescription: "Picking capabilities and setup."
 
 ## Picking
 
-Picking is performed by the World Window. There are four flavors of picking:
+Picking is performed by the WorldWindow. There are four flavors of picking:
 
 - Normal picking returns the visible object or terrain at a specified pick point. See PlacemarksAndPicking.js for an example.
 - Deep picking returns all objects at a specified pick point. See DeepPicking.js for an example.

--- a/content/web/tutorials/picking.md
+++ b/content/web/tutorials/picking.md
@@ -37,11 +37,11 @@ The API for picking is all on the WorldWindow object. The methods are:
 pick for normal and deep picking
 pickTerrain for terrain picking
 pickShapesInRegion for region picking
-For deep picking you set the World Window’s deepPicking property prior to calling the pick method.
+For deep picking you set the WorldWindow’s deepPicking property prior to calling the pick method.
 
 ### Pick Point and Pick Region
 
-The pick point and pick region are specified in screen coordinates, but coordinates relative to the World Window’s canvas. Those coordinates can be easily computed using the canvasCoodinates method of the WorldWindow object, as follows in this call to pick:
+The pick point and pick region are specified in screen coordinates, but coordinates relative to the WorldWindow’s canvas. Those coordinates can be easily computed using the canvasCoodinates method of the WorldWindow object, as follows in this call to pick:
 
 ```javascript
 var pickList = wwd.pick(wwd.canvasCoordinates(x, y));

--- a/content/web/tutorials/world-window.md
+++ b/content/web/tutorials/world-window.md
@@ -1,15 +1,15 @@
 ---
-title: "World Window"
+title: "WorldWindow"
 date: 2017-07-26T15:05:14-05:00
 draft: false
 listdescription: "Notes on the fundamental WorldWind object."
 ---
 
-## World Window
+## WorldWindow
 
-WorldWindow is the fundamental Web WorldWind object. It represents the presence of Web WorldWind in the web page. Almost all interactions between the app and Web WorldWind occur through a World Window.
+WorldWindow is the fundamental Web WorldWind object. It represents the presence of Web WorldWind in the web page. Almost all interactions between the app and Web WorldWind occur through a WorldWindow.
 
-A World Window encapsulates an HTML canvas element. The app developer is responsible for creating the canvas, typically by defining a `<canvas>` element in static HTML. The canvas is given an ID and that ID is handed to the WorldWindow constructor to tell the World Window its drawing surface. The World Window directs all drawing to that canvas. Here’s an example of creating a World Window for a canvas whose ID is “canvasOne”:
+A WorldWindow encapsulates an HTML canvas element. The app developer is responsible for creating the canvas, typically by defining a `<canvas>` element in static HTML. The canvas is given an ID and that ID is handed to the WorldWindow constructor to tell the WorldWindow its drawing surface. The WorldWindow directs all drawing to that canvas. Here’s an example of creating a WorldWindow for a canvas whose ID is “canvasOne”:
 
 ```javascript
 var wwd = new WorldWind.WorldWindow("canvasOne");
@@ -26,21 +26,21 @@ The canvas, itself, is defined in the associated HTML page as follows:
 
 Here the canvas is given an initial width and height of 1000 pixels, but the style element causes it to resize to the width of the containing `<div>` when displayed, and maintain the initial aspect ratio.
 
-A web page may contain multiple World Windows. Each encapsulates a separate canvas and operates independently of the others.
+A web page may contain multiple WorldWindows. Each encapsulates a separate canvas and operates independently of the others.
 
-A World Window contains a Globe, a Navigator and a Layer List. These are all created automatically during construction of the WorldWindow object. The globe and navigator may subsequently be replaced by the app if desired. The layer list holds all layers displayed in that World Window, but it is initially empty. The first thing most apps do is populate it with one or more imagery layers.
+A WorldWindow contains a Globe, a Navigator and a Layer List. These are all created automatically during construction of the WorldWindow object. The globe and navigator may subsequently be replaced by the app if desired. The layer list holds all layers displayed in that WorldWindow, but it is initially empty. The first thing most apps do is populate it with one or more imagery layers.
 
-The World Window manages the display of the virtual globe or 2D map. Apps need do nothing but add layers and perhaps shapes and initiate redraws when it does so. Behind the scenes, the World Window retrieves imagery and elevation from the internet as needed, generates 3D terrain, and traverses the layer list to display its contents. Its associated navigator translates user input to movements of the globe.
+The WorldWindow manages the display of the virtual globe or 2D map. Apps need do nothing but add layers and perhaps shapes and initiate redraws when it does so. Behind the scenes, the WorldWindow retrieves imagery and elevation from the internet as needed, generates 3D terrain, and traverses the layer list to display its contents. Its associated navigator translates user input to movements of the globe.
 
-Picking is also provided by the World Window. See this developer’s guide’s section on [Picking](/web/tutorials/picking/) for more information.
+Picking is also provided by the WorldWindow. See this developer’s guide’s section on [Picking](/web/tutorials/picking/) for more information.
 
 ### Changing the View
 
-See the [Navigation and Viewing](/web/tutorials/navigation-and-viewing/) page to learn how to make the World Window look at a different location on the globe or to otherwise modify its view.
+See the [Navigation and Viewing](/web/tutorials/navigation-and-viewing/) page to learn how to make the WorldWindow look at a different location on the globe or to otherwise modify its view.
 
 ### Event Listeners
 
-A World Window manages all event handlers associated with its canvas. Rather than specifying event handlers directly on the canvas, apps should establish them on the World Window so that it may coordinate event handling with its own. The call to register event handlers is the same as it would be to define event handlers anywhere:
+A WorldWindow manages all event handlers associated with its canvas. Rather than specifying event handlers directly on the canvas, apps should establish them on the WorldWindow so that it may coordinate event handling with its own. The call to register event handlers is the same as it would be to define event handlers anywhere:
 
 ```javascript
 wwd.addEventListener("mousemove", function (event) {...});


### PR DESCRIPTION
The spelling for all instances of "World Wind" and "World Window" have been changed to "WorldWind" and "WorldWindow", respectively. 

Relates to adjustments needed in issue [#58](https://github.com/NASAWorldWind/NASAWorldWind.github.io/issues/58). 