### PR TITLE
Resource path adjustments for WebWorldWind's initial release

### DIFF
--- a/content/android/tutorials/surface-image.md
+++ b/content/android/tutorials/surface-image.md
@@ -38,7 +38,7 @@ public class SurfaceImageFragment extends BasicGlobeFragment {
 
         // Configure a Surface Image to display a remote image showing Mount Etna erupting on July 13th, 2001.
         sector = new Sector(37.46543388598137, 14.60128369746704, 0.45360804083528, 0.75704283995502);
-        String urlString = "http://worldwindserver.net/android/images/etna.jpg";
+        String urlString = "https://worldwind.arc.nasa.gov/android/tutorials/data/etna.jpg";
         SurfaceImage surfaceImageUrl = new SurfaceImage(sector, ImageSource.fromUrl(urlString));
 
         // Add a WorldWindow layer that displays the Surface Image, just before the Atmosphere layer.

--- a/content/web/get-started.md
+++ b/content/web/get-started.md
@@ -33,7 +33,7 @@ in your npm-based project's web root.
 
 Load the latest release library directly from WorldWind's servers.
 
-    <script src="https://files.worldwind.arc.nasa.gov/artifactory/web {{% latestArtifactoryPath url="https://files.worldwind.arc.nasa.gov/artifactory/api/storage/web"%}}/worldwind.min.js" type="text/javascript"/>
+    <script src="https://files.worldwind.arc.nasa.gov/artifactory/web{{% latestArtifactoryPath url="https://files.worldwind.arc.nasa.gov/artifactory/api/storage/web"%}}/worldwind.min.js" type="text/javascript"/>
 
 ---
 
@@ -41,6 +41,6 @@ Load the latest release library directly from WorldWind's servers.
 
 - The latest [GitHub release](https://github.com/NASAWorldWind/WebWorldWind/releases/latest) contains all the WorldWind libraries and code examples.
 
-- [Simplest Usage](/tutorials/simplest-example.md) tutorial
+- [Simplest Usage](/web/tutorials/simplest-example) tutorial
 
-- [Hosting Locally](/tutorials/standalone-example.md) tutorial
+- [Hosting Locally](/web/tutorials/standalone-example) tutorial

--- a/content/web/tutorials/deployment.md
+++ b/content/web/tutorials/deployment.md
@@ -8,34 +8,28 @@ listdescription: "Methods for deploying Web WorldWind."
 
 ## Deployment
 
-Deploying Web WorldWind is easy. In fact, unless you want to run it from your own server there is no deployment required. You simply include a script tag linking to it:
+Deploying Web WorldWind is easy. In fact, unless you want to run it from your own server there is no deployment 
+required. You simply include a script tag linking to it:
 
-```html
-<script src="http://worldwindserver.net/webworldwind/worldwindlib.js" type="text/javascript"></script>
-```
+    <script src="https://files.worldwind.arc.nasa.gov/artifactory/web{{% latestArtifactoryPath url="https://files.worldwind.arc.nasa.gov/artifactory/api/storage/web"%}}/worldwind.min.js" type="text/javascript"/>
 
-To deploy Web WorldWind on your own server, copy the library worldwindlib.js and the images directory from the Web WorldWind release and place them on your web server. The images directory must be a sibling of the library, i.e., exist in the same directory. These files are included in the release zip file.
+To deploy Web WorldWind on your own server, copy the library worldwind.min.js and the images directory from the Web 
+WorldWind release and place them on your web server. The images directory must be a sibling of the library, i.e., exist 
+in the same directory. These files are included in the release zip file.
 
 ## Running Locally
 
-If you do not already have a web server, you can use Python‘s built in HTTP server.
+If you do not already have a web server, you can use Python‘s built in HTTP server. With Python installed on your 
+computer, change directory to the top-level Web WorldWind directory and run the Python HTTP server:
 
-With Python installed on your computer, change directory to the top-level Web WorldWind directory and run the Python HTTP server:
-
-```
-python -m SimpleHTTPServer
-```
+    python -m SimpleHTTPServer
 
 Or if using Python 3:
 
-```
-python -m http.server 8000
-```
+    python -m http.server 8000
 
 Then browse to
 
-```
-http://localhost:8000/examples/BasicExample.html
-```
+    http://localhost:8000/examples/BasicExample.html
 
 and you should see that Web WorldWind example in your web browser.

--- a/content/web/tutorials/simplest-example.md
+++ b/content/web/tutorials/simplest-example.md
@@ -16,9 +16,9 @@ This step-by-step tutorial illustrates how to use Web WorldWind in an HTML file.
 
 First, in the head tag of your HTML, add a script element to include the Web WorldWind library.
 
-    <script src="https://files.worldwind.arc.nasa.gov/artifactory/apps/web/worldwind.min.js" type="text/javascript"/>
+    <script src="https://files.worldwind.arc.nasa.gov/artifactory/web{{% latestArtifactoryPath url="https://files.worldwind.arc.nasa.gov/artifactory/api/storage/web"%}}/worldwind.min.js" type="text/javascript"/>
 
-Next, create an HTML5 canvas, defining its width and heighth. You will also want to include a message for browsers that
+Next, create an HTML5 canvas, defining its width and height. You will also want to include a message for browsers that
 do not support HTML5 Canvas.
 
     <canvas id="canvasOne" width="1024" height="768">
@@ -34,7 +34,8 @@ Finally, you will include a script between the body tags of your HTML, like this
     wwd.addLayer(new WorldWind.BMNGOneImageLayer());
     wwd.addLayer(new WorldWind.BingAerialWithLabelsLayer());
 
-    // Add a compass, a coordinates display and some view controls to the WorldWindow.wwd.addLayer(new WorldWind.CompassLayer());
+    // Add a compass, a coordinates display and some view controls to the WorldWindow.
+    wwd.addLayer(new WorldWind.CompassLayer());
     wwd.addLayer(new WorldWind.CoordinatesDisplayLayer(wwd));
     wwd.addLayer(new WorldWind.ViewControlsLayer(wwd));
 
@@ -54,7 +55,7 @@ Here is what it looks like in a working example:
     <meta charset="UTF-8">
     <title>WorldWind Example</title>
     <!-- Include the Web WorldWind library. -->
-    <script src="http://worldwindserver.net/webworldwind/worldwindlib.min.js" type="text/javascript"/>
+    <script src="https://files.worldwind.arc.nasa.gov/artifactory/web{{% latestArtifactoryPath url="https://files.worldwind.arc.nasa.gov/artifactory/api/storage/web"%}}/worldwind.min.js" type="text/javascript"/>
     </head>
     <body>
     <div style="position: absolute; top: 50px; left: 50px;">
@@ -76,7 +77,8 @@ Here is what it looks like in a working example:
             wwd.addLayer(new WorldWind.BMNGOneImageLayer());
             wwd.addLayer(new WorldWind.BingAerialWithLabelsLayer());
 
-            // Add a compass, a coordinates display and some view controls to the WorldWindow.wwd.addLayer(new WorldWind.CompassLayer());
+            // Add a compass, a coordinates display and some view controls to the WorldWindow.
+            wwd.addLayer(new WorldWind.CompassLayer());
             wwd.addLayer(new WorldWind.CoordinatesDisplayLayer(wwd));
             wwd.addLayer(new WorldWind.ViewControlsLayer(wwd));
         }
@@ -88,7 +90,8 @@ Here is what it looks like in a working example:
 
 ### Runtime Example
 
-If you run this example, the result is a simple, interactive [globe](https://files.worldwind.arc.nasa.gov/artifactory/apps/web/examples/SimplestExample.html).Try zooming in with your mouse wheel (or a pinch gesture for mobile devices). Drag the mouse or your finger to pan
+If you run this example, the result is a simple, [interactive globe](https://files.worldwind.arc.nasa.gov/artifactory/apps/web/examples/SimplestExample.html).
+Try zooming in with your mouse wheel (or a pinch gesture for mobile devices). Drag the mouse or your finger to pan 
 around the globe. Drag the right mouse button or your two fingers upward to tilt the globe.
 
 <br></br>


### PR DESCRIPTION
- Adjusted resource paths in the Web Deployment tutorial
- Adjusted resource paths in the Web Simplest Example tutorial
- Adjusted resource paths in the Web Get Started page
- Adjusted the Android SurfaceImage tutorial resource path to reference https://worldwind.arc.nasa.gov instead of http://worldwindserver.net
- Closes #112 