### PR TITLE
Add event tracking to site

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,5 +3,4 @@ languageCode: "en-us"
 title: "NASA WorldWind"
 metaDataFormat: "yaml"
 cleanDestinationDir: true
-googleAnalytics: "UA-105294289-1"
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,7 +12,7 @@
         <title>{{ block "title" . }}
             {{ .Title }}
         {{ end }}</title>
-        {{ template "_internal/google_analytics.html" . }}
+        {{ partial "google_analytics.html" . }}
     </head>
     <body>
         <!-- Navigation Bar -->     

--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -5,7 +5,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', 'UA-105294289-1', 'auto');
+    ga('create', {{ . }}, 'auto');
     ga('send', 'pageview');
 
     function handleOutboundLinkClicks(event) {

--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -7,5 +7,14 @@
 
     ga('create', 'UA-105294289-1', 'auto');
     ga('send', 'pageview');
+
+    function handleOutboundLinkClicks(event) {
+        ga('send', 'event', {
+            eventCategory: 'Outbound Link',
+            eventAction: 'click',
+            eventLabel: event.target.href,
+            transport: 'beacon'
+        });
+    }
 </script>
 <!-- End Google Analytics -->

--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -5,7 +5,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-    ga('create', {{ . }}, 'auto');
+    ga('create', 'UA-105294289-1', 'auto');
     ga('send', 'pageview');
 
     function handleOutboundLinkClicks(event) {

--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -1,0 +1,11 @@
+<!-- Google Analytics -->
+<script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-105294289-1', 'auto');
+    ga('send', 'pageview');
+</script>
+<!-- End Google Analytics -->


### PR DESCRIPTION
Closes #132 

Will allow tracking for outbound links, e.g. going to a GitHub repo or viewing the Web examples